### PR TITLE
fix websocket import

### DIFF
--- a/pipesock.go
+++ b/pipesock.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bufio"
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 	"encoding/json"
 	"flag"
 	"fmt"


### PR DESCRIPTION
Google shut down code.google.com, so the import did not work any more.